### PR TITLE
Exception fix

### DIFF
--- a/classes/kohana/exception.php
+++ b/classes/kohana/exception.php
@@ -1,0 +1,47 @@
+<?php defined('SYSPATH') or die('No direct access');
+/**
+ * Kohana exception class. Translates exceptions using the [I18n] class.
+ * Modified to work with Wordpress via kohana-for-wordpress plugin [elrolito]
+ *
+ * @package    Kohana
+ * @category   Exceptions
+ * @author     Kohana Team
+ * @copyright  (c) 2008-2009 Kohana Team
+ * @license    http://kohanaphp.com/license
+ */
+class Kohana_Exception extends Exception {
+
+	/**
+	 * Creates a new translated exception.
+	 *
+	 *     throw new Kohana_Exception('Something went terrible wrong, :user',
+	 *         array(':user' => $user));
+	 *
+	 * @param   string   error message
+	 * @param   array    translation variables
+	 * @param   integer  the exception code
+	 * @return  void
+	 */
+	public function __construct($message, array $variables = NULL, $code = 0)
+	{
+		// Set the message, with check for kohana-for-wordpress translate function [elrolito]
+		$message = function_exists('__k') ? __k($message, $variables) : __($message, $variables);
+
+		// Pass the message to the parent
+		parent::__construct($message, $code);
+	}
+
+	/**
+	 * Magic object-to-string method.
+	 *
+	 *     echo $exception;
+	 *
+	 * @uses    Kohana::exception_text
+	 * @return  string
+	 */
+	public function __toString()
+	{
+		return Kohana::exception_text($this);
+	}
+
+} // End Kohana_Exception


### PR DESCRIPTION
Maybe I was the only person getting this error, but I noticed when using your kohana-for-wordpress module that if there was an exception error during a kohana request in wordpress, the __() function would through an error. So I just modified the Kohana_Exception class to check if __k() from the kohana-for-wordpress module existed and used that function instead... not sure if it's absolutely necessary, but as long as this module is running along with the wordpress plugin, everything works... other than having the plugin process all uri requests, still causes some problems in the wordpress admin area, specifically the Pages section.
